### PR TITLE
fix typo in example CSAF file

### DIFF
--- a/examples/example-csaf.json
+++ b/examples/example-csaf.json
@@ -25,7 +25,7 @@
             }
          },
          "id": "CSAF-Document-20221209155839",
-         "initial_relese_data": "2022-12-09T15-58-39Z",
+         "initial_release_date": "2022-12-09T15-58-39Z",
          "revision_history": [
             {
                "date": "2022-12-09T15-58-39Z",


### PR DESCRIPTION
there is a typo in the JSON file.
How I found out:
```
from csaf.parser import CSAFParser
parser = CSAFParser()
parser.parse_file('examples/example-csaf.json')
print(parser.get_metadata())
```
would fail with:

```
Traceback (most recent call last):
  File "/.../csaf/parse.py", line 3, in <module>
    parser.parse_file('examples/example-csaf.json')
  File "/.../csaf/csaf/parser.py", line 28, in parse_file
    self._process_metadata()
  File "/.../csaf/csaf/parser.py", line 77, in _process_metadata
    self.metadata["initial_release_date"] = document["tracking"]["initial_release_date"]
                                            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'initial_release_date'
```